### PR TITLE
Add fallback for /etc

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -89,9 +89,9 @@ func GetTarget() string {
     conf_path := path.Join(homedir, ".meow.conf")
     if _, err := os.Stat(conf_path); !errors.Is(err, os.ErrNotExist) {
         return conf_path
+    } else {
+        return "/etc/meow.conf"
     }
-
-    return ""
 }
 
 func CreateConfig() {


### PR DESCRIPTION
If there is no config found, fallback to a system-wide config in `/etc/meow.conf`