### PR TITLE
Trying to correctly implement /etc/meow.conf fallback

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -3,7 +3,6 @@ package configs
 import (
 	"os"
 	"path"
-	"runtime"
 
 	_ "embed"
 
@@ -12,6 +11,7 @@ import (
 
 var (
     xdg_confdir, XdgConfHomeExist = os.LookupEnv("XDG_CONFIG_HOME")
+    fallback_linuxdir, fallback_linuxExist = os.LookupEnv("/etc/")
     homedir, _          = os.UserHomeDir()
 
     // Config values
@@ -60,9 +60,11 @@ func GetTarget() string {
         return HomeConfigPath
     }
 
-    LinuxFallbackConf := "/etc/meow.conf"
-    if runtime.GOOS == "linux" && checkFileExist(LinuxFallbackConf) {
-        return HomeConfigPath
+    if fallback_linuxExist {
+        fallback_linuxConfPath := path.Join(fallback_linuxdir, "meow.conf")
+        if checkFileExist(fallback_linuxConfPath) {
+            return fallback_linuxConfPath
+        }
     }
 
     return ""


### PR DESCRIPTION
I mean, at least, make it correctly work.
Previously, if you only put a configuration file in `/etc/meow.conf`, meowfetch will first panic due to not finding a configuration in the second looked directory, at the root of the home directory, without checking first the fallback directory. 
```
panic: open /home/pm/.meow.conf: no such file or directory

goroutine 1 [running]:
meowfetch/configs.ParseConfig()
	/home/pm/Documents/meowfetch/configs/config.go:44 +0x4e
main.main()
	/home/pm/Documents/meowfetch/main.go:27 +0x2e
```
I've literally never programmed in go, but I know some basis in programming, and manage to came with a fix, by adding another variable as `fallback_linux` (dir, Exist & ConfPath) which will check for its existence.
One downfall of that, is that it doesn't use the runtime module, but after trying it a bit, it seemed to also display the architecture (from `go tool dist list`), which might or not cause it to not be used properly.
But again, I'm a total beginner, so this might be myself who don't know properly how to use those.
Either way, if you really want to not use another bunch of variables, that's totally fine. But be aware that meowfetch doesn't check for it currently.