### PR TITLE
fix shell version not showing currectly by using env #8

### DIFF
--- a/internals/widgets/shell.go
+++ b/internals/widgets/shell.go
@@ -1,11 +1,11 @@
 package widgets
 
 import (
-    config "meowfetch/configs"
-    "os"
-    "os/exec"
-    "path"
-    "strings"
+	config "meowfetch/configs"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
 )
 
 func W_shell() string {
@@ -26,9 +26,15 @@ func W_shell() string {
     } else {
         switch shell {
         case "bash":
-            ret += " " + os.Getenv("BASH_VERSION")
+            out, err := exec.Command(shell_path, "--version").Output()
+            if err == nil {
+                ret += " " + strings.Split(strings.Split(string(out), "\n")[0], " ")[3]
+            }
         case "zsh":
-            ret += " " + os.Getenv("ZSH_VERSION")
+            out, err := exec.Command(shell_path, "--version").Output()
+            if err == nil {
+                ret += " " + strings.Split(strings.Split(string(out), "\n")[0], " ")[1]
+            }
         case "yash":
             out, err := exec.Command(shell_path, "--version").Output()
             if err == nil {


### PR DESCRIPTION
We used to get shell versions by using their respective environment variables. When there is no environment variable, this will not operate. So, after this commit, we'll use "shell —version" to parse the version. for all the shells. (bash and zsh)